### PR TITLE
tegra-state-scripts: remove the correct file

### DIFF
--- a/meta-mender-tegra/classes/tegra-mender-setup.bbclass
+++ b/meta-mender-tegra/classes/tegra-mender-setup.bbclass
@@ -66,8 +66,8 @@ ROOTFSPART_SIZE = "${@tegra_mender_set_rootfs_partsize(${MENDER_CALC_ROOTFS_SIZE
 # Default for thud and later is grub integration but we need to use u-boot integration already included.
 # Leave out sdimg since we don't use this with tegra (instead use
 # tegraflash)
-MENDER_FEATURES_ENABLE_append = "${@tegra_mender_uboot_feature(d)}"
-MENDER_FEATURES_DISABLE_append = " mender-grub mender-image-uefi"
+MENDER_FEATURES_ENABLE_append_tegra = "${@tegra_mender_uboot_feature(d)}"
+MENDER_FEATURES_DISABLE_append_tegra = " mender-grub mender-image-uefi"
 
 # Use these variables to adjust your total rootfs size across both
 # images. Rootfs size will be approximately 1/2 of
@@ -100,10 +100,12 @@ def tegra_mender_calc_total_size(d):
 
 MENDER_IMAGE_ROOTFS_SIZE_DEFAULT = "${@tegra_mender_image_rootfs_size(d)}"
 TEGRA_MENDER_RESERVED_SPACE_MB ?= "1024"
-MENDER_STORAGE_TOTAL_SIZE_MB ??= "${@tegra_mender_calc_total_size(d)}"
+TEGRA_MENDER_STORAGE_TOTAL_SIZE_MB = "${MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT}"
+TEGRA_MENDER_STORAGE_TOTAL_SIZE_MB_tegra = "${@tegra_mender_calc_total_size(d)}"
+MENDER_STORAGE_TOTAL_SIZE_MB ??= "${TEGRA_MENDER_STORAGE_TOTAL_SIZE_MB}"
 
 def tegra_mender_uboot_feature(d):
-    if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot'):
+    if (d.getVar('PREFERRED_PROVIDER_virtual/bootloader') or '').startswith('cboot'):
         return " mender-persist-systemd-machine-id"
     return " mender-uboot mender-persist-systemd-machine-id"
 

--- a/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script
+++ b/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script
@@ -54,9 +54,11 @@ mount --bind /dev "${mnt}/dev"
 # TNSPEC in the update payload.  But first we have to set up the
 # configuration file with the TNSPEC.
 if [ -L "${mnt}/etc/nv_boot_control.conf" -a -x "${mnt}/usr/bin/setup-nv-boot-control" ]; then
-    rm "${mnt}/etc/nv_boot_control.conf"
+    if [ -f "${mnt}/var/lib/nvbootctrl/nv_boot_control.conf" ]; then
+        rm "${mnt}/var/lib/nvbootctrl/nv_boot_control.conf"
+    fi
     if ! chroot "${mnt}" /usr/bin/setup-nv-boot-control; then
-	echo "ERR: could not initialize nv_boot_control.conf in new rootfs" >&2
+        echo "ERR: could not initialize nv_boot_control.conf in new rootfs" >&2
     fi
 fi
 if ! chroot "${mnt}" /usr/sbin/nv_update_engine --install no-reboot; then

--- a/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script-uboot
+++ b/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script-uboot
@@ -47,9 +47,11 @@ mount --bind /dev "${mnt}/dev"
 # TNSPEC in the update payload. But first we have to set up the
 # configuration file with the TNSPEC.
 if [ -L "${mnt}/etc/nv_boot_control.conf" -a -x "${mnt}/usr/bin/setup-nv-boot-control" ]; then
-    rm "${mnt}/etc/nv_boot_control.conf"
+    if [ -f "${mnt}/var/lib/nvbootctrl/nv_boot_control.conf" ]; then
+        rm "${mnt}/var/lib/nvbootctrl/nv_boot_control.conf"
+    fi
     if ! chroot "${mnt}" /usr/bin/setup-nv-boot-control; then
-	echo "ERR: could not initialize nv_boot_control.conf in new rootfs" >&2
+        echo "ERR: could not initialize nv_boot_control.conf in new rootfs" >&2
     fi
 fi
 if ! chroot "${mnt}" /usr/sbin/nv_update_engine --install no-reboot; then


### PR DESCRIPTION
When updating the nv_boot_control.conf file during the payload update the wrong file was removed. The "${mnt}/etc/nv_boot_control.conf" file is a symbolic link to "${mnt}/var/lib/nvbootctrl/nv_boot_control.conf". When the symbolic link in /etc is removed, the next firmware update will fail.

Instead of removing the symbolic link, the file it points to is removed and recreated after the setup-nv-boot-control script is executed.

Signed-off-by: Boris Nagels <develop@focusware.nl>